### PR TITLE
chore: add package.json to be used in yarn 3.x projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "alpha-lyrae",
     "version": "1.0.0",
-    "license": "MIT",
+    "license": "OFL-1.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/vegaprotocol/alpha-lyrae.git"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "alpha-lyrae",
+    "version": "1.0.0",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/vegaprotocol/alpha-lyrae.git"
+    },
+    "packageManager": "yarn@3.2.3"
+}


### PR DESCRIPTION
Main reason of this change is to make it able to use it in other projects that use yarn 3.x dependency manager, which requires from each dependency to have package.json.